### PR TITLE
Get working with github code spaces

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: "Publish Features"
         uses: devcontainers/action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: devcontainers/action@v1
         with:
           publish-features: "true"
-          oci-registry: "devwasm.azurecr.io"
           base-path-to-features: "./src"
+          generate-docs: "true"
         env:
           DEVCONTAINERS_OCI_AUTH: ${{ secrets.DEVCONTAINERS_OCI_AUTH }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,15 +6,15 @@ jobs:
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    environment: release
     steps:
       - uses: actions/checkout@v2
-      
-      - name: "Publish"
+
+      - name: "Publish Features"
         uses: devcontainers/action@v1
         with:
           publish-features: "true"
           base-path-to-features: "./src"
           generate-docs: "true"
+          
         env:
-          DEVCONTAINERS_OCI_AUTH: ${{ secrets.DEVCONTAINERS_OCI_AUTH }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ jobs:
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This converts the project to publish to github packages instead of a custom container registry so that github code spaces can make use of it