### PR TITLE
Update name for Rust wasm target

### DIFF
--- a/src/rust-wasi/devcontainer-feature.json
+++ b/src/rust-wasi/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust-wasi",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "name": "wasm + wasi for Rust",
     "documentationURL": "https://github.com/dev-wasm/dev-wasm-feature",
     "description": "Installs the web assembly target for rust",

--- a/src/rust-wasi/install.sh
+++ b/src/rust-wasi/install.sh
@@ -7,4 +7,4 @@ if ! which rustup > /dev/null; then
     source $HOME/.cargo/env
 fi
 
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1


### PR DESCRIPTION
This fixes the non-functioning script by renaming the rust target to the correct one.

Closes #11 